### PR TITLE
drivers: stepper: add step and set_direction API support

### DIFF
--- a/drivers/stepper/adi_tmc/tmc22xx.c
+++ b/drivers/stepper/adi_tmc/tmc22xx.c
@@ -150,6 +150,8 @@ static int tmc22xx_stepper_init(const struct device *dev)
 static DEVICE_API(stepper, tmc22xx_stepper_api) = {
 	.enable = tmc22xx_stepper_enable,
 	.disable = tmc22xx_stepper_disable,
+	.step = step_dir_stepper_common_step,
+	.set_direction = step_dir_stepper_common_set_direction,
 	.move_by = step_dir_stepper_common_move_by,
 	.is_moving = step_dir_stepper_common_is_moving,
 	.set_reference_position = step_dir_stepper_common_set_reference_position,

--- a/drivers/stepper/allegro/a4979.c
+++ b/drivers/stepper/allegro/a4979.c
@@ -269,6 +269,8 @@ static int a4979_init(const struct device *dev)
 static DEVICE_API(stepper, a4979_stepper_api) = {
 	.enable = a4979_stepper_enable,
 	.disable = a4979_stepper_disable,
+	.step = step_dir_stepper_common_step,
+	.set_direction = step_dir_stepper_common_set_direction,
 	.move_by = a4979_stepper_move_by,
 	.move_to = a4979_move_to,
 	.is_moving = step_dir_stepper_common_is_moving,

--- a/drivers/stepper/step_dir/step_dir_stepper_common.c
+++ b/drivers/stepper/step_dir/step_dir_stepper_common.c
@@ -345,3 +345,24 @@ int step_dir_stepper_common_set_event_callback(const struct device *dev,
 	data->event_cb_user_data = user_data;
 	return 0;
 }
+
+int step_dir_stepper_common_step(const struct device *dev)
+{
+	return step_dir_stepper_perform_step(dev);
+}
+
+int step_dir_stepper_common_set_direction(const struct device *dev,
+					  enum stepper_direction direction)
+{
+	struct step_dir_stepper_common_data *data = dev->data;
+	const struct step_dir_stepper_common_config *config = dev->config;
+	int ret = 0;
+
+	K_SPINLOCK(&data->lock) {
+		data->direction = direction;
+		ret = gpio_pin_set_dt(&config->dir_pin, (direction == STEPPER_DIRECTION_POSITIVE)
+								? 1 ^ config->invert_direction
+								: 0 ^ config->invert_direction);
+	}
+	return ret;
+}

--- a/drivers/stepper/step_dir/step_dir_stepper_common.h
+++ b/drivers/stepper/step_dir/step_dir_stepper_common.h
@@ -220,6 +220,22 @@ int step_dir_stepper_common_set_event_callback(const struct device *dev,
 					       stepper_event_callback_t callback, void *user_data);
 
 /**
+ * @brief Step the stepper motor by one step in the current direction.
+ * @param dev Pointer to the device structure.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_common_step(const struct device *dev);
+
+/**
+ * @brief Set the direction of the stepper motor.
+ * @param dev Pointer to the device structure.
+ * @param direction The direction to set.
+ * @return 0 on success, or a negative error code on failure.
+ */
+int step_dir_stepper_common_set_direction(const struct device *dev,
+					  enum stepper_direction direction);
+
+/**
  * @brief Handle a timing signal and update the stepper position.
  * @param dev Pointer to the device structure.
  */

--- a/drivers/stepper/ti/drv84xx.c
+++ b/drivers/stepper/ti/drv84xx.c
@@ -478,6 +478,8 @@ static int drv84xx_init(const struct device *dev)
 static DEVICE_API(stepper, drv84xx_stepper_api) = {
 	.enable = drv84xx_enable,
 	.disable = drv84xx_disable,
+	.step = step_dir_stepper_common_step,
+	.set_direction = step_dir_stepper_common_set_direction,
 	.move_by = drv84xx_move_by,
 	.move_to = drv84xx_move_to,
 	.is_moving = step_dir_stepper_common_is_moving,

--- a/include/zephyr/drivers/stepper.h
+++ b/include/zephyr/drivers/stepper.h
@@ -212,11 +212,27 @@ typedef int (*stepper_stop_t)(const struct device *dev);
 typedef int (*stepper_is_moving_t)(const struct device *dev, bool *is_moving);
 
 /**
+ * @brief Step the stepper motor by one step in the current direction.
+ *
+ * @see stepper_step() for details.
+ */
+typedef int (*stepper_step_t)(const struct device *dev);
+
+/**
+ * @brief Set the direction of the stepper motor.
+ *
+ * @see stepper_set_direction() for details.
+ */
+typedef int (*stepper_set_direction_t)(const struct device *dev, enum stepper_direction direction);
+
+/**
  * @brief Stepper Driver API
  */
 __subsystem struct stepper_driver_api {
 	stepper_enable_t enable;
 	stepper_disable_t disable;
+	stepper_step_t step;
+	stepper_set_direction_t set_direction;
 	stepper_set_micro_step_res_t set_micro_step_res;
 	stepper_get_micro_step_res_t get_micro_step_res;
 	stepper_set_reference_position_t set_reference_position;
@@ -538,6 +554,50 @@ static inline int z_impl_stepper_is_moving(const struct device *dev, bool *is_mo
 		return -ENOSYS;
 	}
 	return api->is_moving(dev, is_moving);
+}
+
+/**
+ * @brief Step the stepper motor by one step in the current direction.
+ *
+ * @param dev pointer to the stepper driver instance
+ *
+ * @retval -EIO General input / output error
+ * @retval -ENOSYS If not implemented by device driver
+ * @retval 0 Success
+ */
+__syscall int stepper_step(const struct device *dev);
+
+static inline int z_impl_stepper_step(const struct device *dev)
+{
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
+
+	if (api->step == NULL) {
+		return -ENOSYS;
+	}
+	return api->step(dev);
+}
+
+/**
+ * @brief Set the direction of the stepper motor.
+ *
+ * @param dev pointer to the stepper driver instance
+ * @param direction The direction to set
+ *
+ * @retval -EIO General input / output error
+ * @retval -ENOSYS If not implemented by device driver
+ * @retval 0 Success
+ */
+__syscall int stepper_set_direction(const struct device *dev, enum stepper_direction direction);
+
+static inline int z_impl_stepper_set_direction(const struct device *dev,
+					       enum stepper_direction direction)
+{
+	const struct stepper_driver_api *api = (const struct stepper_driver_api *)dev->api;
+
+	if (api->set_direction == NULL) {
+		return -ENOSYS;
+	}
+	return api->set_direction(dev, direction);
 }
 
 /**


### PR DESCRIPTION
Introduced `step` and `set_direction` API functions to the stepper interface.
This update includes implementations in the common stepper code and integrates
them into device-specific drivers like Allegro A4979, TI DRV84xx, and TMC22xx.

The `step` function enables stepping the motor by one step in the current
direction, and the `set_direction` function allows setting the motor's
direction. These changes are a preparation for further stepper API
refactorings.